### PR TITLE
Adding support for /tagged/

### DIFF
--- a/lib/tumblrwks.js
+++ b/lib/tumblrwks.js
@@ -52,11 +52,11 @@ tumblr.prototype.get = function (url, params, callback){
 
     req.end();    
   }else{
-
+    var prefix = this._isTaggedAPI(url) ? ('') : ('/blog/' + host);
     if(_needApiKey){
-      var path = apiVersion + '/blog/' + host + url + '?api_key=' + this.consumerKey + '&' + this._getParamsString(params);
+      var path = apiVersion + prefix + url + '?api_key=' + this.consumerKey + '&' + this._getParamsString(params);
     }else{
-      var path = apiVersion + '/blog/' + host + url + '?' + this._getParamsString(params);
+      var path = apiVersion + prefix + url + '?' + this._getParamsString(params);
     }
 
     var options = {
@@ -176,7 +176,11 @@ tumblr.prototype._getHostName = function (params) {
 
 // all the user methods need OAuth
 tumblr.prototype._isUserAPI = function (url){
-  return url.indexOf('/user/') == 0;
+  return url.indexOf('/user/') === 0;
+};
+
+tumblr.prototype._isTaggedAPI = function (url){
+  return url.indexOf('/tagged') === 0;
 };
 
 module.exports = tumblr;


### PR DESCRIPTION
Hi,

I found that your library didn't support the tagged method (http://www.tumblr.com/docs/en/api/v2#tagged-method), so I added it in. Hope it's of use to you.

Paul
